### PR TITLE
Update the maximum upload file size in the terms of service

### DIFF
--- a/resources/views/accounts/legals.blade.php
+++ b/resources/views/accounts/legals.blade.php
@@ -93,7 +93,7 @@
     <p>Some limits also apply to our services:</p>
 
     <ul>
-        <li><b>File Upload</b> is limited to 10MB per file. There is no other limit (total volume or time) regarding the storage of those files</li>
+        <li><b>File Upload</b> is limited to 50MB per file. There is no other limit (total volume or time) regarding the storage of those files</li>
         <li><b>XMPP and HTTP connections</b> we have some connection limitations in place, both on our XMPP services and web services to limit the bandwidth and amount of requests per user</li>
         <li><b>XMPP registration</b> also known as "In-band registration" is disabled on our services. To register an account you must use our <a href="{{ route('accounts.register') }}">Registration page</a></li>
     </ul>


### PR DESCRIPTION
The terms of service currently say that the max upload file size is 10MB.
But the actual value is 50MB.